### PR TITLE
Update resnet50_hot.yaml

### DIFF
--- a/blogs/resnet/recipes/resnet50_hot.yaml
+++ b/blogs/resnet/recipes/resnet50_hot.yaml
@@ -53,6 +53,8 @@ dataloader:
   timeout: 0.0
 device:
   gpu: {}
+eval_batch_size: 2048
+eval_interval: 1 
 loggers:
   progress_bar:
     console_log_level: EPOCH


### PR DESCRIPTION
* Explicitly specify following parameters in the `hot` recipe (as is done in `mild` and `medium` recieps) to fix parsing error:
```
eval_batch_size: 2048
eval_interval: 1
```