### PR TITLE
Tie up weights of embedding layer and lm_head

### DIFF
--- a/llm/llm/gpt.py
+++ b/llm/llm/gpt.py
@@ -118,6 +118,10 @@ class GPT(nn.Module):
                                  bias=False,
                                  device=device)
 
+        # lm_head and embedding weights should be tied: https://aclanthology.org/E17-2025.pdf
+        # HF transformers has this in transformers/modeling_utils.py; function _tie_or_clone_weights()
+        self.lm_head.weight = self.transformer.wte.weight
+
         if device != 'meta':
             self.apply(self.param_init_fn)
 


### PR DESCRIPTION
This has been a common practice in GPT/Bloom/OPT models according to the paper: https://aclanthology.org/E17-2025.pdf

The code for tying up weights exists within modeling_utils.py in transformers repository (https://github.com/huggingface/transformers/blob/main/src/transformers/modeling_utils.py#L1198) and is achieved by calling ``self.post_init()`` in GPT2/Bloom models.

However, I could not find the code for tying up the weights in GPT class within this repo.
On further inspection (by running ``torch.sum(model.lm_head.weight - model.transformer.wte.weight)``), I found that this is not equal to 0, which it should be if the weights were tied.