### PR TITLE
Prevent accidental `torch`, `torchvision` or `torchtext` upgrades 

### DIFF
--- a/llm/requirements.txt
+++ b/llm/requirements.txt
@@ -1,3 +1,6 @@
+torchvision<0.14
+torchtext<0.14
+torch<1.13
 mosaicml==0.11.0
 mosaicml-streaming<1
 flash_attn @ git+https://github.com/HazyResearch/flash-attention.git@main


### PR DESCRIPTION
Composer and this benchmarks/llm repo is not yet ready for torch 1.13. These edits ensure that we do not accidentally upgrade torch directly or via any of the subpackages `torchvision` and `torchtext`. 