### PR TITLE
Add codeowners for each existing benchmark

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+/llm/ @vchiley @bmosaicml @abhi-mosaic @dakinggg @dblalock
+/deeplab/ @Landanjs @A-Jacobson @coryMosaicML @dblalock
+/resnet/ @Landanjs @growlix @A-Jacobson @coryMosaicML @dblalock


### PR DESCRIPTION
3-line change. Not adding owners for BERT until that PR is in.