### PR TITLE
Raise error if global batch size not divisible by world size

### DIFF
--- a/bert/main.py
+++ b/bert/main.py
@@ -114,6 +114,10 @@ def main(cfg):
     print(f'{n_params=:.4e}')
 
     # Get batch size info
+    if cfg.global_train_batch_size % dist.get_world_size() != 0:
+        raise ValueError(f'Global batch size {cfg.global_train_batch_size} is not divisible by {dist.get_world_size()} '
+                         'as a result, the batch size would be truncated, please adjust `global_train_batch_size` '
+                         f'to be divisible by world size, {dist.get_world_size()}.')
     device_train_batch_size = cfg.global_train_batch_size // dist.get_world_size()
     device_eval_batch_size = cfg.get('global_eval_batch_size', cfg.global_train_batch_size) // dist.get_world_size()
 

--- a/llm/main.py
+++ b/llm/main.py
@@ -62,7 +62,6 @@ def calculate_batch_size_info(global_batch_size, device_microbatch_size):
                          'as a result, the batch size will be truncated, please adjust `global_batch_size` '
                          f'to be divisible by world size, {dist.get_world_size()}.')
     device_batch_size = global_batch_size // dist.get_world_size()
-    print ("calculated batch size now is: ", device_batch_size * dist.get_world_size())
     if device_microbatch_size == 'auto':
         device_grad_accum = 'auto'
     elif isinstance(device_microbatch_size, int):

--- a/llm/main.py
+++ b/llm/main.py
@@ -57,7 +57,12 @@ def build_scheduler(cfg):
 
 
 def calculate_batch_size_info(global_batch_size, device_microbatch_size):
+    if global_batch_size % dist.get_world_size() != 0:
+        raise ValueError(f'Global batch size {global_batch_size} is not divisible by {dist.get_world_size()} '
+                         'as a result, the batch size will be truncated, please adjust `global_batch_size` '
+                         f'to be divisible by world size, {dist.get_world_size()}.')
     device_batch_size = global_batch_size // dist.get_world_size()
+    print ("calculated batch size now is: ", device_batch_size * dist.get_world_size())
     if device_microbatch_size == 'auto':
         device_grad_accum = 'auto'
     elif isinstance(device_microbatch_size, int):

--- a/llm/main.py
+++ b/llm/main.py
@@ -59,7 +59,7 @@ def build_scheduler(cfg):
 def calculate_batch_size_info(global_batch_size, device_microbatch_size):
     if global_batch_size % dist.get_world_size() != 0:
         raise ValueError(f'Global batch size {global_batch_size} is not divisible by {dist.get_world_size()} '
-                         'as a result, the batch size will be truncated, please adjust `global_batch_size` '
+                         'as a result, the batch size would be truncated, please adjust `global_batch_size` '
                          f'to be divisible by world size, {dist.get_world_size()}.')
     device_batch_size = global_batch_size // dist.get_world_size()
     if device_microbatch_size == 'auto':


### PR DESCRIPTION
Adding an error if global batch size is not divisible by world size, otherwise this will silently error. 

Addresses:
[CO-1463](https://mosaicml.atlassian.net/jira/software/c/projects/CO/issues/CO-1463?filter=myopenissues)